### PR TITLE
Fix ID and pagetext on addpage

### DIFF
--- a/actions/template.php
+++ b/actions/template.php
@@ -72,7 +72,7 @@ class syntax_plugin_bureaucracy_action_template extends syntax_plugin_bureaucrac
         // resolve templates
         $_templates = array();
         foreach($templates as $k => $v) {
-            resolve_pageid($myns, $v, $junk); // resolve template
+            resolve_pageid($myns, $k, $junk); // resolve template
             $_templates[cleanID("$pagename:$k")] = $v; // $pagename is already resolved
         }
         $templates = $_templates;

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    bureaucracy
 author  Andreas Gohr
 email   andi@splitbrain.org
-date    2013-02-06
+date    2013-05-29
 name    Bureaucracy Plugin
 desc    Create forms and generate pages or emails from them
 url     http://www.dokuwiki.org/plugin:bureaucracy


### PR DESCRIPTION
Previously the page text was used to generate the full wiki id of a page.
