### PR TITLE
Fixes the false-negative _validate() result

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -124,6 +124,8 @@ class syntax_plugin_bureaucracy extends DokuWiki_Syntax_Plugin {
      */
     function render($format, &$R, $data) {
         global $ID;
+        $revalidate = false;
+        
         if ($format != 'xhtml') return false;
         $R->info['cache'] = false; // don't cache
 
@@ -132,7 +134,9 @@ class syntax_plugin_bureaucracy extends DokuWiki_Syntax_Plugin {
          * @var $opt syntax_plugin_bureaucracy_field */
         foreach ($data['data'] as $id => &$opt) {
             if(isset($opt->opt['value'])) {
+                $opt->opt['value'] == "@MAIL@" && $revalidate = true;
                 $opt->opt['value'] = $this->replace($opt->opt['value']);
+                $revalidate && $opt->setVal($opt->opt['value']);
             }
 
         }


### PR DESCRIPTION
When the default value for the email field is set like:

email "email (opcjonalne)" "=@MAIL@" !

the plugin fails to _validate() it properly, because the replacement takes place after the execution of _validate().
The fix forces revalidation upon replacement when the "@MAIL@" value is encountered.
