### PR TITLE
Removed unused strings. It should be accepted by translation tool too

### DIFF
--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -30,24 +30,3 @@ $lang['template_thanks'] = 'Die Seite wurde angelegt, folgen Sie dem Link um die
 $lang['summary']         = 'Created from the formular at %s';
 
 $lang['submit']          = 'Absenden';
-
-$lang['js']['month_names'][0] = 'Januar';
-$lang['js']['month_names'][1] = 'Februar';
-$lang['js']['month_names'][2] = 'März';
-$lang['js']['month_names'][3] = 'April';
-$lang['js']['month_names'][4] = 'Mai';
-$lang['js']['month_names'][5] = 'Juni';
-$lang['js']['month_names'][6] = 'Juli';
-$lang['js']['month_names'][7] = 'August';
-$lang['js']['month_names'][8] = 'September';
-$lang['js']['month_names'][9] = 'Oktober';
-$lang['js']['month_names'][10] = 'November';
-$lang['js']['month_names'][11] = 'Dezember';
-
-$lang['js']['weekdays'][0] = 'So';
-$lang['js']['weekdays'][1] = 'Mo';
-$lang['js']['weekdays'][2] = 'Di';
-$lang['js']['weekdays'][3] = 'Mi';
-$lang['js']['weekdays'][4] = 'Do';
-$lang['js']['weekdays'][5] = 'Fr';
-$lang['js']['weekdays'][6] = 'Sa';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -31,24 +31,3 @@ $lang['template_thanks'] = 'The page has been created, follow the link to open i
 $lang['summary']         = 'Created from the form at %s';
 
 $lang['submit']         = 'Submit';
-
-$lang['js']['month_names'][0] = 'January';
-$lang['js']['month_names'][1] = 'February';
-$lang['js']['month_names'][2] = 'March';
-$lang['js']['month_names'][3] = 'April';
-$lang['js']['month_names'][4] = 'May';
-$lang['js']['month_names'][5] = 'June';
-$lang['js']['month_names'][6] = 'July';
-$lang['js']['month_names'][7] = 'August';
-$lang['js']['month_names'][8] = 'September';
-$lang['js']['month_names'][9] = 'October';
-$lang['js']['month_names'][10] = 'November';
-$lang['js']['month_names'][11] = 'December';
-
-$lang['js']['weekdays'][0] = 'Sun';
-$lang['js']['weekdays'][1] = 'Mon';
-$lang['js']['weekdays'][2] = 'Tue';
-$lang['js']['weekdays'][3] = 'Wed';
-$lang['js']['weekdays'][4] = 'Thu';
-$lang['js']['weekdays'][5] = 'Fri';
-$lang['js']['weekdays'][6] = 'Sat';

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -22,30 +22,9 @@ $lang['e_template']      = 'Template "%s" introuvable. Il n\'existe pas ou vous 
 $lang['e_denied']        = 'Vous n\'avez pas le droit de cr&eacute;er cette page, vous &ecirc;tes vous connect&eacute; ?';
 
 $lang['mailsubject']     = 'Donn&eacute;es du formulaire soumis &agrave; %s';
-$lang['mailintro']       = 'Les donn&eacute;es suivantes on &eacute;t&eacute; envoyées vers %s.';
+$lang['mailintro']       = 'Les donn&eacute;es suivantes on &eacute;t&eacute; envoy&eacute;es vers %s.';
 
 $lang['mail_thanks']     = 'Donn&eacute;es envoy&eacute;es avec succ&egrave;s. Merci.';
 $lang['template_thanks'] = 'La page a &eacute;t&eacute; cr&eacute;&eacute;e, suivez le lien pour l\'ouvrir.';
 
 $lang['summary']         = 'Cr&eacute;&eacute; depuis le formulaire %s';
-
-$lang['js']['month_names'][0] = 'Janvier';
-$lang['js']['month_names'][1] = 'Février';
-$lang['js']['month_names'][2] = 'Mars';
-$lang['js']['month_names'][3] = 'Avril';
-$lang['js']['month_names'][4] = 'Mai';
-$lang['js']['month_names'][5] = 'Juin';
-$lang['js']['month_names'][6] = 'Juillet';
-$lang['js']['month_names'][7] = 'Août';
-$lang['js']['month_names'][8] = 'Septembre';
-$lang['js']['month_names'][9] = 'Octobre';
-$lang['js']['month_names'][10] = 'Novembre';
-$lang['js']['month_names'][11] = 'Decembre';
-
-$lang['js']['weekdays'][0] = 'Dim';
-$lang['js']['weekdays'][1] = 'Lun';
-$lang['js']['weekdays'][2] = 'Mar';
-$lang['js']['weekdays'][3] = 'Mer';
-$lang['js']['weekdays'][4] = 'Jeu';
-$lang['js']['weekdays'][5] = 'Ven';
-$lang['js']['weekdays'][6] = 'Sam';

--- a/lang/lv/lang.php
+++ b/lang/lv/lang.php
@@ -27,24 +27,3 @@ $lang['summary']         = 'Izveidots no veidlapas  %s';
 
 
 $lang['submit'] = 'Saglabāt';
-
-$lang['js']['month_names'][0] = 'janvāris';
-$lang['js']['month_names'][1] = 'februāris'; 
-$lang['js']['month_names'][2] = 'marts'; 
-$lang['js']['month_names'][3] = 'aprīlis'; 
-$lang['js']['month_names'][4] = 'maijs'; 
-$lang['js']['month_names'][5] = 'jūnijs'; 
-$lang['js']['month_names'][6] = 'jūlijs'; 
-$lang['js']['month_names'][7] = 'augusts'; 
-$lang['js']['month_names'][8] = 'septembris'; 
-$lang['js']['month_names'][9] = 'oktobris'; 
-$lang['js']['month_names'][10] = 'novembris'; 
-$lang['js']['month_names'][11] = 'decembris';
-
-$lang['js']['weekdays'][0] = 'Sv'; 
-$lang['js']['weekdays'][1] = 'P'; 
-$lang['js']['weekdays'][2] = 'O'; 
-$lang['js']['weekdays'][3] = 'T'; 
-$lang['js']['weekdays'][4] = 'C'; 
-$lang['js']['weekdays'][5] = 'Pk';
-$lang['js']['weekdays'][6] = 'S'; 

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -31,24 +31,3 @@ $lang['template_thanks'] = 'De pagina is aangemaakt, volg de link om hem te open
 $lang['summary']         = 'Gemaakt door het formulier op %s';
 
 $lang['submit']         = 'Submit';
-
-$lang['js']['month_names'][0] = 'januari';
-$lang['js']['month_names'][1] = 'februari';
-$lang['js']['month_names'][2] = 'maart';
-$lang['js']['month_names'][3] = 'april';
-$lang['js']['month_names'][4] = 'mei';
-$lang['js']['month_names'][5] = 'juni';
-$lang['js']['month_names'][6] = 'juli';
-$lang['js']['month_names'][7] = 'augustus';
-$lang['js']['month_names'][8] = 'september';
-$lang['js']['month_names'][9] = 'oktober';
-$lang['js']['month_names'][10] = 'november';
-$lang['js']['month_names'][11] = 'december';
-
-$lang['js']['weekdays'][0] = 'zon';
-$lang['js']['weekdays'][1] = 'ma';
-$lang['js']['weekdays'][2] = 'din';
-$lang['js']['weekdays'][3] = 'woe';
-$lang['js']['weekdays'][4] = 'don';
-$lang['js']['weekdays'][5] = 'vr';
-$lang['js']['weekdays'][6] = 'zat';

--- a/lang/pt-br/lang.php
+++ b/lang/pt-br/lang.php
@@ -30,24 +30,3 @@ $lang['template_thanks'] = 'A página foi criada, clique no link para abri-la.';
 $lang['summary']         = 'Criada a partir do formulário em %s.';
 
 $lang['submit']         = 'Enviar';
-
-$lang['js']['month_names'][0] = 'Janeiro';
-$lang['js']['month_names'][1] = 'Fevereiro';
-$lang['js']['month_names'][2] = 'Março';
-$lang['js']['month_names'][3] = 'Abril';
-$lang['js']['month_names'][4] = 'Maio';
-$lang['js']['month_names'][5] = 'Junho';
-$lang['js']['month_names'][6] = 'Julho';
-$lang['js']['month_names'][7] = 'Agosto';
-$lang['js']['month_names'][8] = 'Setembro';
-$lang['js']['month_names'][9] = 'Outubro';
-$lang['js']['month_names'][10] = 'Novembro';
-$lang['js']['month_names'][11] = 'Dezembro';
-
-$lang['js']['weekdays'][0] = 'Dom';
-$lang['js']['weekdays'][1] = 'Seg';
-$lang['js']['weekdays'][2] = 'Ter';
-$lang['js']['weekdays'][3] = 'Qua';
-$lang['js']['weekdays'][4] = 'Qui';
-$lang['js']['weekdays'][5] = 'Sex';
-$lang['js']['weekdays'][6] = 'Sáb';


### PR DESCRIPTION
The date strings aren't used anymore.

The datepicker has possibility to be regionalized. But that should be provided via DokuWiki core. e.g. https://github.com/jquery/jquery-ui/tree/master/ui/i18n
