### PR TITLE
Add an argument for select field

### DIFF
--- a/helper/fieldselect.php
+++ b/helper/fieldselect.php
@@ -14,12 +14,21 @@ class helper_plugin_bureaucracy_fieldselect extends helper_plugin_bureaucracy_fi
      *  - label
      *  - option1|option2|etc
      *  - ^ (optional)
-     *
+     *  - selection1|selection2|etc#option1|option2|etc  
+     * 
      * @param array $args The tokenized definition, only split at spaces
      */
     public function initialize($args) {
         $this->init($args);
-        $this->opt['args'] = array_map('trim', explode('|',array_shift($args)));
+        $total_params=array_map('trim', explode('#',array_shift($args)));
+		if (!isset($total_params[1])) 
+		    {$this->opt['args'] = array_map('trim', explode('|',$total_params[0]));
+			$this->opt['show_params'] = $this->opt['args'];
+			}
+     		else 
+			{$this->opt['args'] = array_map('trim', explode('|',$total_params[1]));
+			 $this->opt['show_params'] = array_map('trim', explode('|',$total_params[0]));
+			}
         $this->standardArgs($args);
         if (!isset($this->opt['value']) && isset($this->opt['optional'])) {
             array_unshift($this->opt['args'],' ');
@@ -45,12 +54,13 @@ class helper_plugin_bureaucracy_fieldselect extends helper_plugin_bureaucracy_fi
             $params['class'] = 'bureaucracy_error';
         }
         $params = array_merge($this->opt, $params);
+        $this->opt['show_params'] = array_combine($params['args'],$this->opt['show_params']);
         $form->addElement(call_user_func_array('form_makeListboxField',
                                                 $this->_parse_tpl(
                                                     array(
                                                         '@@NAME@@',
-                                                        $params['args'],
-                                                        '@@VALUE|' . $params['args'][0] . '@@',
+                                                        $this->opt['show_params'],
+                                                        '@@VALUE|' . $this->opt['show_params'][0] . '@@',
                                                         '@@DISPLAY@@',
                                                         '@@ID@@',
                                                         '@@CLASS@@'


### PR DESCRIPTION
Using the argument 'selection1|selection2|etc#option1|option2|etc' . 
It shows 'selection1' 'selection2'...... on  dropdown list , and it will actually transmit 'option1' 'option2' to the template.