### PR TITLE
do not run handle_post when depends_on is empty

### DIFF
--- a/helper/fieldfieldset.php
+++ b/helper/fieldfieldset.php
@@ -66,7 +66,7 @@ class helper_plugin_bureaucracy_fieldfieldset extends helper_plugin_bureaucracy_
      * @return bool Whether the passed value is valid
      */
     public function handle_post($value, &$fields, $index, $formid) {
-        if(!empty($this->depends_on)) {
+        if(empty($this->depends_on)) {
             return true;
         }
 

--- a/helper/fieldfieldset.php
+++ b/helper/fieldfieldset.php
@@ -66,7 +66,7 @@ class helper_plugin_bureaucracy_fieldfieldset extends helper_plugin_bureaucracy_
      * @return bool Whether the passed value is valid
      */
     public function handle_post($value, &$fields, $index, $formid) {
-        if(!isset($this->depends_on)) {
+        if(!empty($this->depends_on)) {
             return true;
         }
 


### PR DESCRIPTION
isset(array()) returns true

this fixes an issue, which accours if fieldset has no label