### PR TITLE
Fix strangly ignored fieldsets after addpage line

### DIFF
--- a/helper/fieldfieldset.php
+++ b/helper/fieldfieldset.php
@@ -66,7 +66,7 @@ class helper_plugin_bureaucracy_fieldfieldset extends helper_plugin_bureaucracy_
      * @return bool Whether the passed value is valid
      */
     public function handle_post($value, &$fields, $index, $formid) {
-        if(!isset($this->depends_on)) {
+        if(empty($this->depends_on)) {
             return true;
         }
 


### PR DESCRIPTION
This bug is caused by specific circumstances. Fieldsets with no dependency, (i.e. those that are always shown) have their ``$this->depends_on`` set to an empty array. However that empty array still evaluates to true with ``isset()``, see [line 69](https://github.com/splitbrain/dokuwiki-plugin-bureaucracy/blob/faddfe9036fa848239b59b643ed32783fc3cbec4/helper/fieldfieldset.php#L69).

Further, in [line 77](https://github.com/splitbrain/dokuwiki-plugin-bureaucracy/blob/faddfe9036fa848239b59b643ed32783fc3cbec4/helper/fieldfieldset.php#L77) ``$this->depends_on[0]`` always evaluates to ``null`` since ``$this->depends_on`` is an empty array. However since ``addpage`` fields do not have a label, ``$field->getParam('label')`` evaluates to ``null`` in that line as well!

Since ``$field->isSet_()`` in line [line 84](https://github.com/splitbrain/dokuwiki-plugin-bureaucracy/blob/faddfe9036fa848239b59b643ed32783fc3cbec4/helper/fieldfieldset.php#L84) may evaluate to ``null`` as well, our unrelated fieldset may be treated as hidden even though it is not.

This should fix #164 