### PR TITLE
use correct field on dependent fieldsets

### DIFF
--- a/helper/action.php
+++ b/helper/action.php
@@ -90,10 +90,33 @@ class helper_plugin_bureaucracy_action extends syntax_plugin_bureaucracy {
      * @return array
      */
     function prepareFieldReplacements($fields) {
+        $use_fieldset = true;
+        
         foreach ($fields as $field) {
             $label = $field->getParam('label');
             $value = $field->getParam('value');
 
+             if($field->getFieldType() === 'fieldset') {
+                if(!empty($field->depends_on)) {
+                    foreach($fields as $field_tmp) {
+                        if($field_tmp->getParam('label') === $field->depends_on[0] && $field_tmp->getParam('value') !== $field->depends_on[1]) {
+                            $use_fieldset = false;
+                        } else if ($field_tmp->getParam('label') === $field->depends_on[0] && $field_tmp->getParam('value') === $field->depends_on[1]) {
+                            $use_fieldset = true;
+                        }
+                    }
+                } else {
+                    $use_fieldset = true;
+                }
+            }  
+            
+            if(!$use_fieldset) continue;
+
+            if($field->getParam('cmd') == 'textarea') {
+                $value = str_replace("\r", '', $value);
+                $value = str_replace("\n", ' \\\\\\\\ ', $value);
+            }
+            
             //field replacements
             $this->prepareFieldReplacement($label, $value);
         }

--- a/helper/action.php
+++ b/helper/action.php
@@ -111,11 +111,6 @@ class helper_plugin_bureaucracy_action extends syntax_plugin_bureaucracy {
             }  
             
             if(!$use_fieldset) continue;
-
-            if($field->getParam('cmd') == 'textarea') {
-                $value = str_replace("\r", '', $value);
-                $value = str_replace("\n", ' \\\\\\\\ ', $value);
-            }
             
             //field replacements
             $this->prepareFieldReplacement($label, $value);


### PR DESCRIPTION
when dependent fieldsets are used only the last field with the same name is taken.

@Klap-in @micgro42 can you have a look at it?

it is more or less used in mailaction to only get the correct fieldset. (https://github.com/splitbrain/dokuwiki-plugin-bureaucracy/blob/master/helper/actionmail.php#L105)