### PR TITLE
Bug fix for text area field

### DIFF
--- a/helper/actionmail.php
+++ b/helper/actionmail.php
@@ -166,7 +166,7 @@ class helper_plugin_bureaucracy_actionmail extends helper_plugin_bureaucracy_act
             $html = '<tr><td colspan="2"><u>'.hsc($column1).'<u></td></tr>';
             $text = "\n=====".$column1.'=====';
         } else {
-            $html = '<tr><td><b>'.hsc($column1).'<b></td><td>'.hsc($column2).'</td></tr>';
+            $html = '<tr><td><b>'.hsc($column1).'<b></td><td>'.nl2br(hsc($column2)).'</td></tr>';
             $text = "\n $column1 \t\t $column2";
         }
         return array($html, $text);

--- a/helper/fieldtextarea.php
+++ b/helper/fieldtextarea.php
@@ -20,7 +20,7 @@ class helper_plugin_bureaucracy_fieldtextarea extends helper_plugin_bureaucracy_
     protected $tpl =
 '<label class="@@CLASS@@">
     <span>@@DISPLAY@@</span>
-    <textarea name="@@NAME@@" id="@@ID@@" rows="@@ROWS|10@@" cols="10" class="edit @@OPTIONAL|required" required="required@@">@@VALUE@@</textarea>
+    <textarea name="@@NAME@@" id="@@ID@@" rows="@@ROWS|10@@" cols="10" class="edit @@OPTIONAL|required@@" required="@@OPTIONAL|required@@">@@VALUE@@</textarea>
 </label>';
 
 }


### PR DESCRIPTION
In fact, there are two bug fixes related to text area field in this PR.

1. correct HTML generation

before
`<textarea name="bureaucracy[11]" id="" rows="15" cols="10" class="edit required&quot; required=&quot;required"></textarea>`

after
`<textarea name="bureaucracy[11]" id="" rows="15" cols="10" class="edit required" required="required"></textarea>`

2. correct e-mail generation

New lines in text area content are replaced by &lt;br&gt; tags in the e-mail text.
