### PR TITLE
Changed prepareFieldReplacement function

### DIFF
--- a/helper/action.php
+++ b/helper/action.php
@@ -67,7 +67,7 @@ class helper_plugin_bureaucracy_action extends syntax_plugin_bureaucracy {
      * @param string $value field value
      */
     function prepareFieldReplacement($label, $value) {
-        if(!is_null($label)) {
+        if(!is_null($label) && !is_null($value)) {
             $this->patterns[$label] = '/(@@|##)' . preg_quote($label, '/') .
                 '(?:\|(.*?))' . (is_null($value) ? '' : '?') .
                 '\1/si';


### PR DESCRIPTION
I found that if using conditional selectboxes having all the same label, replacement goes wrong. E.G.: i have this form:
<form>
...
usemailtemplate tpl_mailform
...
fieldset ""
select "Object" "O1|O2|O3"

fieldset "" "Object" "O1"
select "Issue" "0021 (K21)|0022 (K22)|0023 (K23)|0024 (K24)|0025 (K11)|0026 (K12)|0027 (K63)|0028 (K71)|0029 (K14)|0031 (K31)|0032 (K32)"

fieldset "" "Object" "O2"
select "Issue" "0030 (K73)|0033 (K33)|0034 (K41)|0035 (K42)|0036 (K43)|0037 (K44)|0068 (K81)"

fieldset "" "Object" "O3"
select "Issue" "0038 (MK01)|0039 (WK01)"
...
</form>

In the tpl_mailform i use placeholders like "@@Object@@" and "@@Issue@@".

As you can see, only one of the select-boxes named "Issue" can be selected in the form and will contain a valid value, later on. If i select the first object "O1" and give it a value and process the form, the function "prepareFieldReplacement()" is called with the first label/value but also the second and third, where there is no value. So they will overwrite each other and the last one wins!
You can check this by selecting "O3" and an "Issue" and will get a correct result. All other object selections leads to a non-replaced placeholder.

My PR fix this by not only checking for a not-null $label, but also for a not-null $value.
