### PR TITLE
upload files to arbitrary locations

### DIFF
--- a/_test/fieldfile.test.php
+++ b/_test/fieldfile.test.php
@@ -3,7 +3,7 @@
  * @group plugin_bureaucracy
  * @group plugins
  */
-class syntax_plugin_bureaucracy_filefield_test extends DokuWikiTest {
+class syntax_plugin_bureaucracy_fieldfile_test extends DokuWikiTest {
 
     protected $pluginsEnabled = array('bureaucracy');
 

--- a/_test/fieldfile.test.php
+++ b/_test/fieldfile.test.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * @group plugin_bureaucracy
+ * @group plugins
+ */
+class syntax_plugin_bureaucracy_filefield_test extends DokuWikiTest {
+
+    protected $pluginsEnabled = array('bureaucracy');
+
+    /**
+     * Parse doku $syntax and check if any resulting xhtml element can be selected by $pqSelector
+     *
+     * @param $syntax
+     * @param $pqSelector
+     */
+    protected function assertPqSelector($syntax, $pqSelector) {
+        $xhtml = p_render('xhtml', p_get_instructions($syntax), $info);
+        $doc = phpQuery::newDocument($xhtml);
+        $result = pq($pqSelector, $doc);
+        $this->assertEquals(1, $result->length, "selector: \"$pqSelector\" not found in\n$xhtml\n");
+    }
+
+    /**
+     * Chceck if defined namespace doesn't violate $standardArgs
+     */
+    function test_syntax() {
+        $standardArgs = array(
+            '!' => 'input[type=file].edit',
+            '^' => 'input[type=file][required].edit.required',
+            '@' => 'input[type=file][required].edit.required',
+            '! /regex/' => 'input[type=file].edit',
+            '@ /regex/ "**Example error"' => 'input[type=file][required].edit.required'
+        );
+
+        //upload namespace not defined
+        foreach ($standardArgs as $arg => $pqSelector) {
+            $input = "<form>\nfile \"Some label\" $arg\n</form>";
+            $this->assertPqSelector($input, $pqSelector);
+        }
+
+        //upload namespace defined, nothing shoud change in syntax
+        foreach ($standardArgs as $arg => $pqSelector) {
+            $input = "<form>\nfile \"Some label\" upload:here $arg\n</form>";
+            $this->assertPqSelector($input, $pqSelector);
+        }
+
+        //upload namespace in ""
+        foreach ($standardArgs as $arg => $pqSelector) {
+            $input = "<form>\nfile \"Some label\" \"upload:here\" $arg\n</form>";
+            $this->assertPqSelector($input, $pqSelector);
+        }
+    }
+
+    /**
+     * Parse the bureaucracy form syntax and simulate a file upload
+     *
+     * @param $form_syntax bureaucracy form syntax containg only one file field
+     * @return string a name of the uploaded file
+     */
+    protected function simulate_file_upload($form_syntax) {
+        $media = 'img.png';
+        $media_src = mediaFN('wiki:dokuwiki-128.png');
+
+        $syntax_plugin = new syntax_plugin_bureaucracy();
+        $data = $syntax_plugin->handle($form_syntax, 0, 0, new Doku_Handler());
+
+        $actionData = $data['actions'][0];
+        $action = plugin_load('helper', $actionData['actionname']);
+
+        $fileField = $data['fields'][0];
+
+        //mock file upload
+        $file = array(
+            'name'     => $media,
+            'type'     => 'image/png',
+            'size'     => filesize($media_src),
+            'tmp_name' => $media_src
+        );
+        //this is the only field
+        $index = 0;
+        //this is the only form
+        $form_id = 0;
+        $fileField->handle_post($file, $data['fields'], $index, $form_id);
+
+        //upload file
+        $action->run(
+            $data['fields'],
+            $data['thanks'],
+            $actionData['argv']
+        );
+
+        return $media;
+    }
+
+    function test_action_template_upload_default() {
+        $template_id = 'template_upload_default';
+        $id = 'upload_default';
+
+        saveWikiText($template_id, 'Value:@@Some label@@', 'summary');
+
+        $form_syntax = "<form>action template $template_id $id\nfile \"Some label\"\n</form>";
+        $media = $this->simulate_file_upload($form_syntax);
+
+        //check if file exists where we suspect it to be
+        $this->assertTrue(file_exists(mediaFN("$id:$media")));
+    }
+
+    function test_action_template_upload_absolute() {
+        $template_id = 'template_upload_absolute';
+        $id = 'upload_absolute';
+        $upload_ns = 'upload:ns';
+
+        saveWikiText($template_id, 'Value:@@Some label@@', 'summary');
+
+        $form_syntax = "<form>action template $template_id $id\nfile \"Some label\" $upload_ns\n</form>";
+        $media = $this->simulate_file_upload($form_syntax);
+
+        //check if file exists where we suspect it to be
+        $this->assertTrue(file_exists(mediaFN("$upload_ns:$media")));
+    }
+
+    function test_action_template_upload_relative() {
+        $template_id = 'template_upload_relative';
+        $id = 'upload_relative';
+        $upload_ns_rel = 'upload:ns';
+        $upload_ns = ".:$upload_ns_rel";
+
+        saveWikiText($template_id, 'Value:@@Some label@@', 'summary');
+
+        $form_syntax = "<form>action template $template_id $id\nfile \"Some label\" \"$upload_ns\"\n</form>";
+        $media = $this->simulate_file_upload($form_syntax);
+
+        //check if file exists where we suspect it to be
+        $this->assertTrue(file_exists(mediaFN("$id:$upload_ns:$media")));
+    }
+
+}

--- a/helper/actiontemplate.php
+++ b/helper/actiontemplate.php
@@ -340,13 +340,13 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
      * @throws Exception
      */
     protected function processUploads($fields) {
-        $ns = $this->pagename;
         foreach($fields as $field) {
 
             if($field->getFieldType() !== 'file') continue;
 
             $label = $field->getParam('label');
             $file  = $field->getParam('file');
+            $ns    = $field->getParam('namespace');
 
             //skip empty files
             if(!$file['size']) {
@@ -355,16 +355,20 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
             }
 
             $id = $ns.':'.$file['name'];
-            $id = cleanID($id);
+            resolve_mediaid($this->pagename, $id, $ignored); // resolve relatives
 
             $auth = $this->aclcheck($id); // runas
-
+            $move = 'copy_uploaded_file';
+            //prevent from is_uploaded_file() check
+            if(defined('DOKU_UNITTEST')) {
+                $move = 'copy';
+            }
             $res = media_save(
                 array('name' => $file['tmp_name']),
                 $id,
                 false,
                 $auth,
-                'copy_uploaded_file');
+                $move);
 
             if(is_array($res)) throw new Exception($res[0]);
 

--- a/helper/fieldfile.php
+++ b/helper/fieldfile.php
@@ -14,7 +14,16 @@ class helper_plugin_bureaucracy_fieldfile extends helper_plugin_bureaucracy_fiel
      * @param array $args The tokenized definition, only split at spaces
      */
     function initialize($args) {
-        parent::initialize($args);
+        $this->init($args);
+
+        //default namespace for file upload (pagepath:file_name)
+        $this->opt['namespace'] = '.';
+
+        //check whenever the first argument is an upload namespace
+        if (isset($args[0]) && preg_match('/^[a-z.\-_:]+$/', $args[0])) {
+            $this->opt['namespace'] = array_shift($args);
+        }
+        $this->standardArgs($args);
 
         $attr = array();
         if(!isset($this->opt['optional'])) {
@@ -51,7 +60,7 @@ class helper_plugin_bureaucracy_fieldfile extends helper_plugin_bureaucracy_fiel
     protected function _validate() {
         global $lang;
         parent::_validate();
-        
+
         $file = $this->getParam('file');
         if($file['error'] == 1 || $file['error'] == 2) {
             throw new Exception(sprintf($lang['uploadsize'],filesize_h(php_to_byte(ini_get('upload_max_filesize')))));


### PR DESCRIPTION
This commit provides an addtional "file" syntax which allows us to decide where we want to store files send by bureaucracy forms. The new optional additional argument (directly after the label) is a dokuwiki namespace where the files are uploaded. We can use "." and ".." to define the namespace relative to a newly created page. By default "." is used as an file upload namespace.

The commit only affects the template action.