### PR TITLE
extends 'user' and 'users' template replacement syntax

### DIFF
--- a/_test/BureaucracyTest.php
+++ b/_test/BureaucracyTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace dokuwiki\plugin\bureaucracy\test;
+
+
+class BureaucracyTest extends \DokuWikiTest {
+    protected $pluginsEnabled = array('bureaucracy');
+
+    /**
+     * Simulate sending of bureaucracy form
+     *
+     * @param string $form_syntax       syntax to build a bureaucracy form
+     * @param string $template_syntax   syntax used as a page template for the "action template"
+     * @param array& $validation_errors field labels that were invalid
+     * @param string|array ...$values   values passed to form handler
+     * @return string content of newly created page
+     */
+    protected function send_form_action_template($form_syntax, $template_syntax, &$validation_errors, ...$values) {
+        if (is_array($values[0])) {
+            $values = $values[0];
+        }
+        $id = uniqid('page');
+        $template_id = uniqid('template');
+
+        //create full form syntax
+        if (is_array($form_syntax)) $form_syntax = implode("\n", $form_syntax);
+        $form_syntax = "<form>\naction template $template_id $id\n$form_syntax\n</form>";
+
+        saveWikiText($template_id, $template_syntax, 'summary');
+
+        $syntax_plugin = plugin_load('syntax', 'bureaucracy');
+        $data = $syntax_plugin->handle($form_syntax, 0, 0, new \Doku_Handler());
+
+        $actionData = $data['actions'][0];
+        $action = plugin_load('helper', $actionData['actionname']);
+        //this is the only form
+        $form_id = 0;
+
+        for ($i = 0; $i < count($data['fields']); ++$i) {
+            //set null for not existing values
+            if (!isset($values[$i])) $values[$i] = null;
+
+            $field = $data['fields'][$i];
+            $isValid = $field->handle_post($values[$i], $data['fields'], $i, $form_id);
+            if (!$isValid) {
+                $validation_errors[] = $field->getParam('label');
+            }
+        }
+
+        $action->run(
+            $data['fields'],
+            $data['thanks'],
+            $actionData['argv']
+        );
+
+        return rawWiki($id);
+    }
+}

--- a/_test/fielduser.test.php
+++ b/_test/fielduser.test.php
@@ -1,0 +1,216 @@
+<?php
+namespace dokuwiki\plugin\bureaucracy\test;
+
+/**
+ * @group plugin_bureaucracy
+ * @group plugins
+ */
+class syntax_plugin_bureaucracy_fielduser_test extends BureaucracyTest {
+
+    /**
+     * Create some users
+     */
+    public function setUp() {
+        parent::setUp();
+
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+
+        $auth->createUser("user1", "54321", "a User", "you@example.com");
+        $auth->createUser("user2", "543210", "You", "he@example.com");
+        $auth->createUser("mwuser", "12345", "Wiki User", "me@example.com", array('group1', 'gropu2'));
+    }
+
+    /**
+     * Simulate a bureaucracy form send with the 'user' field
+     *
+     * @param string       $template_syntax     template to be used as form action
+     * @param string|array $users               value of 'users' field or array('label' => 'own label', 'value' => 'value')
+     * @param bool         $assertValid         should we assert the form validity
+     * @param array        &$validation_errors  labels of invalid form fields
+     *
+     * @return string content of newly created page
+     * @throws \Exception
+     */
+    protected function send_form($template_syntax, $user, $assertValid=true, &$validation_errors=array()) {
+        $label = 'user';
+        if (is_array($user)) {
+            if (!isset($user['value'])) {
+                throw new \Exception('$user should be string or array("label" => label, "value" => value');
+            }
+            if (isset($user['label'])) $label = $user['label'];
+            $user = $user['value'];
+        }
+        $result = parent::send_form_action_template('user "'.$label.'"', $template_syntax, $validation_errors, $user);
+        if ($assertValid) {
+            $this->assertEmpty($validation_errors, 'validation error: fields not valid: '.implode(', ', $validation_errors));
+        }
+
+        return $result;
+    }
+
+    public function test_regex_label() {
+        $label = '*]]'; //somthing to break a regex when not properly quoted
+        $user = array('label' => $label, 'value' => 'mwuser');
+        $result = $this->send_form("user:@@$label@@", $user);
+        $this->assertEquals("user:$user[value]", $result);
+    }
+
+    public function test_action_template_default_substitution() {
+        $user = 'mwuser';
+        $result = $this->send_form('user:@@user@@', $user);
+        $this->assertEquals("user:$user", $result);
+    }
+
+    public function test_action_template_empty_substitution() {
+        $template_syntax = 'user:@@user@@';
+        $validation_errors = array();
+        $result = $this->send_form($template_syntax, '', false, $validation_errors);
+        $this->assertEquals(array('user'), $validation_errors);
+    }
+
+    public function test_action_template_name_substitution() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+        $name = $auth->getUserData($user)['name'];
+
+        $result = $this->send_form('user:@@user.name@@', $user);
+        $this->assertEquals("user:$name", $result);
+    }
+
+    public function test_action_template_email_substitution() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+        $mail = $auth->getUserData($user)['mail'];
+
+        $result = $this->send_form('user:@@user.mail@@', $user);
+        $this->assertEquals("user:$mail", $result);
+    }
+
+    public function test_action_template_group_substitution_default_delimiter() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+        $delimiter = ', ';
+        $grps = implode($delimiter, $auth->getUserData($user)['grps']);
+
+        $result = $this->send_form('user:@@user.grps@@', $user);
+        $this->assertEquals("user:$grps", $result);
+    }
+
+    //user.grps(, )
+    public function test_action_template_group_substitution_custom_delimiter() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+        $delimiter = ';';
+        $grps = implode($delimiter, $auth->getUserData($user)['grps']);
+
+        $result = $this->send_form("user:@@user.grps($delimiter)@@", $user);
+        $this->assertEquals("user:$grps", $result);
+    }
+
+    //user.grps(, )
+    public function test_action_template_group_substitution_custom_delimiter_with_brackets() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+        $delimiter = ')';
+        $grps = implode($delimiter, $auth->getUserData($user)['grps']);
+
+        $result = $this->send_form("user:@@user.grps($delimiter)@@", $user);
+        $this->assertEquals("user:$grps", $result);
+    }
+
+    public function test_action_template_unknown_user_substitution() {
+        $template_syntax = 'user:@@user@@';
+        $user = 'no_such_user';
+
+        $validation_errors = array();
+        $result = $this->send_form('user:@@user@@', $user, false, $validation_errors);
+        $this->assertEquals(array('user'), $validation_errors);
+    }
+
+    public function test_action_template_unknown_attribute_substitution() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $template_syntax = 'user:@@user.no_sutch_attribute@@';
+        $user = 'mwuser';
+
+        $result = $this->send_form($template_syntax, $user);
+        $this->assertEquals($template_syntax, $result);
+    }
+
+    public function test_action_template_hash_subsitution() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $template_syntax = 'user:##user##';
+        $user = 'mwuser';
+
+        $result = $this->send_form($template_syntax, $user);
+        $this->assertEquals('user:mwuser', $result);
+    }
+
+    public function test_action_template_hash_subsitution_with_attribute() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+        $mail = $auth->getUserData($user)['mail'];
+
+        $result = $this->send_form('user:##user.mail##', $user);
+        $this->assertEquals("user:$mail", $result);
+    }
+
+
+    public function test_action_template_hash_at_sign_mismatch() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $template_syntax = 'user:##user@@';
+        $user = 'mwuser';
+
+        $result = $this->send_form($template_syntax, $user);
+        $this->assertEquals($template_syntax, $result);
+    }
+
+    public function test_action_template_multiple_replacements() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+        $mail = $auth->getUserData($user)['mail'];
+
+        $delimiter = "\n";
+        $grps = implode($delimiter, $auth->getUserData($user)['grps']);
+
+        $result = $this->send_form("user:@@user@@\n\nmail:@@user.mail@@\n\ngrps:@@user.grps($delimiter)@@", $user);
+        $this->assertEquals("user:$user\n\nmail:$mail\n\ngrps:$grps", $result);
+    }
+
+    public function test_action_template_grps_twice() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+
+        $delimiter1 = "\n";
+        $delimiter2 = "()";
+        $grps1 = implode($delimiter1, $auth->getUserData($user)['grps']);
+        $grps2 = implode($delimiter2, $auth->getUserData($user)['grps']);
+
+        $result = $this->send_form("grps1:@@user.grps($delimiter1)@@\n\ngrps2:@@user.grps($delimiter2)@@", $user);
+        $this->assertEquals("grps1:$grps1\n\ngrps2:$grps2", $result);
+    }
+
+    public function test_action_template_grps_special_glue() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $user = 'mwuser';
+
+        $delimiter = "end)";
+        $grps = implode($delimiter, $auth->getUserData($user)['grps']);
+
+        $result = $this->send_form("grps:@@user.grps($delimiter)@@", $user);
+        $this->assertEquals("grps:$grps", $result);
+    }
+
+}

--- a/_test/fieldusers.test.php
+++ b/_test/fieldusers.test.php
@@ -1,0 +1,193 @@
+<?php
+namespace dokuwiki\plugin\bureaucracy\test;
+
+/**
+ * @group plugin_bureaucracy
+ * @group plugins
+ */
+class syntax_plugin_bureaucracy_fieldusers_test extends BureaucracyTest {
+
+    /**
+     * Create some users
+     */
+    public function setUp() {
+        parent::setUp();
+
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+
+        $auth->createUser("user1", "54321", "a User", "you@example.com");
+        $auth->createUser("user2", "543210", "You", "he@example.com");
+        $auth->createUser("mwuser", "12345", "Wiki User", "me@example.com", array('group1', 'gropu2'));
+    }
+
+    /**
+     * Simulate a bureaucracy form send with the 'users' field
+     *
+     * @param string       $template_syntax     template to be used as form action
+     * @param string|array $users               value of 'users' field or array('label' => 'own label', 'value' => 'value')
+     * @param bool         $assertValid         should we assert the form validity
+     * @param array        &$validation_errors  labels of invalid form fields
+     *
+     * @return string content of newly created page
+     * @throws \Exception
+     */
+    protected function send_form($template_syntax, $users, $assertValid=true, &$validation_errors=array()) {
+        $label = 'users';
+        if (is_array($users)) {
+            if (!isset($users['value'])) {
+                throw new \Exception('$users should be string or array("label" => label, "value" => value');
+            }
+            if (isset($users['label'])) $label = $users['label'];
+            $users = $users['value'];
+        }
+        $result = parent::send_form_action_template('users "'.$label.'"', $template_syntax, $validation_errors, $users);
+        if ($assertValid) {
+            $this->assertEmpty($validation_errors, 'validation error: fields not valid: '.implode(', ', $validation_errors));
+        }
+
+        return $result;
+    }
+
+    public function test_regex_label() {
+        $label = '*]]'; //somthing to break a regex when not properly quoted
+        $user = array('label' => $label, 'value' => 'user1, user2');
+        $result = $this->send_form("users:@@$label@@", $user);
+        $this->assertEquals("users:$user[value]", $result);
+    }
+
+    public function test_mixed_case_and_spaces_label_names_substitution() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+
+        $label = 'tHis Is UsEr';
+        $users = array('user1', 'user2');
+        $names = array_map(function($user) use ($auth) {
+            return $auth->getUserData($user)['name'];
+        }, $users);
+
+        $users_i = implode(', ', $users);
+        $names_i = implode(', ', $names);
+
+        $user = array('label' => $label, 'value' => $users_i);
+        $result = $this->send_form("user:@@$label.name@@", $user);
+        $this->assertEquals("user:$names_i", $result);
+    }
+
+
+    public function test_action_template_default_substitution() {
+        $users = 'user1, user2';
+        $result = $this->send_form('users:@@users@@', $users);
+        $this->assertEquals("users:$users", $result);
+    }
+
+    public function test_action_template_empty_substitution() {
+        $template_syntax = 'users:@@users@@';
+        $validation_errors = array();
+        $result = $this->send_form($template_syntax, '', false, $validation_errors);
+        $this->assertEquals(array('users'), $validation_errors);
+    }
+
+    public function test_action_template_substitution_custom_delimiter() {
+        $users = array('user1', 'user2');
+        $delimiter = ';';
+
+        $post_users = implode(', ', $users);
+        $reuslt_users = implode($delimiter, $users);
+
+        $result = $this->send_form("users:@@users($delimiter)@@", $post_users);
+        $this->assertEquals("users:$reuslt_users", $result);
+    }
+
+    public function test_action_template_substitution_new_line_delimiter() {
+        $users = array('user1', 'user2');
+        $delimiter = "\n";
+
+        $post_users = implode(', ', $users);
+        $reuslt_users = implode($delimiter, $users);
+
+        $result = $this->send_form("users:@@users($delimiter)@@", $post_users);
+        $this->assertEquals("users:$reuslt_users", $result);
+    }
+
+    public function test_action_template_substitution_empty_delimiter() {
+        $users = array('user1', 'user2');
+        $delimiter = '';
+
+        $post_users = implode(', ', $users);
+        $reuslt_users = implode($delimiter, $users);
+
+        $result = $this->send_form("users:@@users($delimiter)@@", $post_users);
+        $this->assertEquals("users:$reuslt_users", $result);
+    }
+
+    public function test_action_template_names_substitution_default_delitmiter() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $users = array('user1', 'user2');
+        $names = array_map(function($user) use ($auth) {
+            return $auth->getUserData($user)['name'];
+        }, $users);
+
+        $delimiter = ', ';
+        $users_i = implode(', ', $users);
+        $names_i = implode($delimiter, $names);
+
+        $result = $this->send_form('users:@@users.name@@', $users_i);
+        $this->assertEquals("users:$names_i", $result);
+    }
+
+    public function test_action_template_names_substitution_custom_delitmiter() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $users = array('user1', 'user2');
+        $names = array_map(function($user) use ($auth) {
+            return $auth->getUserData($user)['name'];
+        }, $users);
+
+        $delimiter = ';';
+        $users_i = implode(', ', $users);
+        $names_i = implode($delimiter, $names);
+
+        $result = $this->send_form("users:@@users($delimiter).name@@", $users_i);
+        $this->assertEquals("users:$names_i", $result);
+    }
+
+    public function test_action_template_mails_substitution_default_delitmiter() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $users = array('user1', 'user2');
+        $mails = array_map(function($user) use ($auth) {
+            return $auth->getUserData($user)['mail'];
+        }, $users);
+
+        $delimiter = ', ';
+        $users_i = implode(', ', $users);
+        $mails_i = implode($delimiter, $mails);
+
+        $result = $this->send_form('users:@@users.mail@@', $users_i);
+        $this->assertEquals("users:$mails_i", $result);
+    }
+
+    public function test_action_template_multiple_replacements() {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+        $users = array('user1', 'user2');
+        $names = array_map(function($user) use ($auth) {
+            return $auth->getUserData($user)['name'];
+        }, $users);
+        $mails = array_map(function($user) use ($auth) {
+            return $auth->getUserData($user)['mail'];
+        }, $users);
+
+        $names_delimiter = "\n";
+        $mails_delimiter = ', ';
+        $users_i = implode(', ', $users);
+        $names_i = implode($names_delimiter, $names);
+        $mails_i = implode($mails_delimiter, $mails);
+
+        $result = $this->send_form("mails:@@users.mail@@\n\nnames:@@users($names_delimiter).name@@", $users_i);
+        $this->assertEquals("mails:$mails_i\n\nnames:$names_i", $result);
+    }
+
+}

--- a/helper/action.php
+++ b/helper/action.php
@@ -63,15 +63,14 @@ class helper_plugin_bureaucracy_action extends syntax_plugin_bureaucracy {
     /**
      * Adds replacement pattern for fieldlabels (e.g @@Label@@)
      *
-     * @param string $label field label
-     * @param string $value field value
+     * @param helper_plugin_bureaucracy_field $field
      */
-    function prepareFieldReplacement($label, $value) {
+    function prepareFieldReplacement($field) {
+        $label = $field->getParam('label');
+
         if(!is_null($label)) {
-            $this->patterns[$label] = '/(@@|##)' . preg_quote($label, '/') .
-                '(?:\|(.*?))' . (is_null($value) ? '' : '?') .
-                '\1/si';
-            $this->values[$label] = is_null($value) || $value === false ? '$2' : $value;
+            $this->patterns[$label] = $field->getReplacementPattern();
+            $this->values[$label] = $field->getReplacementValue();
         }
     }
 
@@ -91,11 +90,8 @@ class helper_plugin_bureaucracy_action extends syntax_plugin_bureaucracy {
      */
     function prepareFieldReplacements($fields) {
         foreach ($fields as $field) {
-            $label = $field->getParam('label');
-            $value = $field->getParam('value');
-
             //field replacements
-            $this->prepareFieldReplacement($label, $value);
+            $this->prepareFieldReplacement($field);
         }
     }
 

--- a/helper/field.php
+++ b/helper/field.php
@@ -212,6 +212,30 @@ class helper_plugin_bureaucracy_field extends syntax_plugin_bureaucracy {
     }
 
     /**
+     * Get the replacement pattern used by action
+     *
+     * @return string
+     */
+    public function getReplacementPattern() {
+        $label = $this->opt['label'];
+        $value = $this->opt['value'];
+        return '/(@@|##)' . preg_quote($label, '/') .
+            '(?:\|(.*?))' . (is_null($value) ? '' : '?') .
+            '\1/si';
+    }
+
+    /**
+     * Get the value used by action
+     * If value is a callback preg_replace_callback is called instead preg_replace
+     *
+     * @return mixed|string
+     */
+    public function getReplacementValue() {
+        $value = $this->opt['value'];
+        return is_null($value) || $value === false ? '$2' : $value;
+    }
+
+    /**
      * Validate value and stores it
      *
      * @param mixed $value value entered into field

--- a/helper/fielduser.php
+++ b/helper/fielduser.php
@@ -20,6 +20,68 @@ class helper_plugin_bureaucracy_fielduser extends helper_plugin_bureaucracy_fiel
     }
 
     /**
+     * Allow receiving user attributes by ".". Ex. user.name
+     * You can pass an optional argument to user.grps enclosed in brackets, used as an groups delimiter Ex. user.grps(, )
+     *
+     * @return string
+     */
+    public function getReplacementPattern() {
+        $label = $this->opt['label'];
+
+        return '/(@@|##)' . preg_quote($label, '/') .
+            '(?:\.(.*?))?' .    //match attribute after "."
+            '(?:\((.*?)\))?' .  //match parameter enclosed in "()". Used for grps separator
+            '\1/si';
+    }
+
+    /**
+     * Used as an callback for preg_replace_callback
+     *
+     * @param $matches
+     * @return string
+     */
+    public function replacementValueCallback($matches) {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+
+        $value = $this->opt['value'];
+        //attr doesn't exists
+        if (!isset($matches[2])) {
+            return is_null($value) || $value === false ? $matches[0] : $value;
+        }
+        $attr = $matches[2];
+
+        $udata = $auth->getUserData($value);
+        //no such user
+        if ($udata === false) {
+            return $matches[0];
+        }
+
+        switch($attr) {
+            case 'name':
+            case 'mail':
+                return $udata[$attr];
+            case 'grps':
+                $delitmiter = ', ';
+                if (isset($matches[3])) {
+                    $delitmiter = $matches[3];
+                }
+                return implode($delitmiter, $udata['grps']);
+            default:
+                return $matches[0];
+        }
+    }
+
+    /**
+     * Return the callback for user replacement
+     *
+     * @return array
+     */
+    public function getReplacementValue() {
+        return array($this, 'replacementValueCallback');
+    }
+
+    /**
      * Validate value of field
      *
      * @throws Exception when user not exists

--- a/helper/fieldusers.php
+++ b/helper/fieldusers.php
@@ -20,6 +20,63 @@ class helper_plugin_bureaucracy_fieldusers extends helper_plugin_bureaucracy_fie
     }
 
     /**
+     * Allow receiving user attributes by ".". Ex. user.name
+     * You can pass an optional argument to user.grps enclosed in brackets, used as an groups delimiter Ex. user.grps(, )
+     *
+     * @return string
+     */
+    public function getReplacementPattern() {
+        $label = $this->opt['label'];
+        return '/(@@|##)' . preg_quote($label, '/') .
+            '(?:\((?P<delimiter>.*?)\))?' .//delimiter
+            '(?:\.(?P<attribute>.*?))?' .  //match attribute after "."
+            '\1/si';
+    }
+
+    /**
+     * Used as an callback for preg_replace_callback
+     *
+     * @param $matches
+     * @return string
+     */
+    public function replacementValueCallback($matches) {
+        /** @var DokuWiki_Auth_Plugin $auth */
+        global $auth;
+
+        $value = $this->opt['value'];
+        //copy the value by default
+        if (count($matches[2]) == 2) {
+            return is_null($value) || $value === false ? $matches[0] : $value;
+        }
+
+        $attribute = isset($matches['attribute']) ? $matches['attribute'] : '';
+        //check if matched string containts a pair of brackets
+        $delimiter = preg_match('/\(.*\)/s', $matches[0]) ? $matches['delimiter'] : ', ';
+        $users     = array_map('trim', explode(',', $value));
+
+        switch($attribute) {
+            case '':
+                return implode($delimiter, $users);
+            case 'name':
+            case 'mail':
+                return implode($delimiter, array_map(function ($user) use ($auth, $attribute) {
+                    return $auth->getUserData($user)[$attribute];
+                }, $users));
+            default:
+                return $matches[0];
+        }
+    }
+
+    /**
+     * Return the callback for user replacement
+     *
+     * @return array
+     */
+    public function getReplacementValue() {
+        return array($this, 'replacementValueCallback');
+    }
+
+    /**
      * Validate value of field
      *
      * @throws Exception when user not exists

--- a/syntax.php
+++ b/syntax.php
@@ -463,7 +463,19 @@ class syntax_plugin_bureaucracy extends DokuWiki_Syntax_Plugin {
      * @return string processed text
      */
     function replace($input, $strftime = true) {
-        $input = preg_replace($this->patterns, $this->values, $input);
+        foreach ($this->values as $label => $value) {
+            $pattern = $this->patterns[$label];
+            if (is_callable($value)) {
+                $input = preg_replace_callback(
+                    $pattern,
+                    $value,
+                    $input
+                );
+            } else {
+                $input = preg_replace($pattern, $value, $input);
+            }
+
+        }
 
         if($strftime) {
             $input = preg_replace_callback(


### PR DESCRIPTION
New 'user' field replacements:
  - '@@user.name@@' replaced by user full name
  - '@@user.mail@@' replaced by user e-mail address
  - '@@user.grps@@' replaced by user grps, comma separated
  - '@@user.grps(separator)@@' replaced by user groups,  separated by 'separator'

New 'users' field replacements:
  - '@@users(separator)@@' - replaced by list of user's nicks, separated by 'separator'
  - '@@users(separator).name' - replaced by list of user's full names, separated by 'separator'
  - '@@users(separator).mail' - replaced by list of user's emails, separated by 'separator'
  - separator may be omitted then the comma is used as a separator. Eg. @@users.mail@@, @@users.name@@
  - @@users.grps@@ is not supported

This commit only affects the template action