### PR TITLE
Change actionscript handler class prefix

### DIFF
--- a/helper/actionscript.php
+++ b/helper/actionscript.php
@@ -32,6 +32,13 @@ class helper_plugin_bureaucracy_actionscript extends helper_plugin_bureaucracy_a
         $classFragment = substr($scriptName, 0, strpos($scriptName, '.'));
         $className = 'helper_plugin_bureaucracy_handler_' . $classFragment;
 
+        $deprecatedClassName = 'bureaucracy_handler_' . $classFragment;
+        if (!class_exists($className) && class_exists($deprecatedClassName)) {
+            msg("Please change this script's class-name to <code>$className</code>.
+Your current scheme <code>$deprecatedClassName</code> is deprecated and will stop working in the future.", 2);
+            $className = $deprecatedClassName;
+        }
+
         /** @var dokuwiki\plugin\bureaucracy\interfaces\bureaucracy_handler_interface $handler */
         $handler = new $className;
 

--- a/helper/actionscript.php
+++ b/helper/actionscript.php
@@ -30,7 +30,7 @@ class helper_plugin_bureaucracy_actionscript extends helper_plugin_bureaucracy_a
         require $path;
 
         $classFragment = substr($scriptName, 0, strpos($scriptName, '.'));
-        $className = 'bureaucracy_handler_' . $classFragment;
+        $className = 'helper_plugin_bureaucracy_handler_' . $classFragment;
 
         /** @var dokuwiki\plugin\bureaucracy\interfaces\bureaucracy_handler_interface $handler */
         $handler = new $className;


### PR DESCRIPTION
The class name prefix is now 'helper_plugin_bureaucracy_', so that
handlers can use the Bureaucracy plugin's language strings.

Fixes #219