### PR TITLE
Remove '-' from scriptNamePattern valid chars

### DIFF
--- a/helper/actionscript.php
+++ b/helper/actionscript.php
@@ -2,7 +2,7 @@
 
 class helper_plugin_bureaucracy_actionscript extends helper_plugin_bureaucracy_action {
 
-    protected $scriptNamePattern = '/^[-_a-zA-Z0-9]+\.php$/';
+    protected $scriptNamePattern = '/^[_a-zA-Z0-9]+\.php$/';
 
     /**
      * @inheritDoc


### PR DESCRIPTION
Since '-' is not a valid char for PHP keywords, it cannot be used in the
script handler file name, as we would get an error when submitting the
form (either because the class was not found, or because of a syntax
error in the script).

Given a form as shown below and the corresponding _test-1.php_ script with a class named `bureaucracy_handler_test_1` (with underscore)
```
<form>
Action script test-1.php
submit "Test"
</form>
```
We get the following:
```
Fatal error: Uncaught Error: Class 'bureaucracy_handler_test-1' not found in /path/to/bureaucracy/helper/actionscript.php on line 36
```
And of course if class is named `bureaucracy_handler_test-1` we get a syntax error 
```
Parse error: syntax error, unexpected '-', expecting '{' in /path/to/conf/plugin/bureaucracy/test-1.php on line 4 
```
