### PR TITLE
Fix broken travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 php:
+  - "7.1"
   - "7.0"
   - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
 before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
 install: sh travis.sh
 script: cd _test && phpunit --stderr --group plugin_bureaucracy


### PR DESCRIPTION
Remove PHP 5.3, 5.4 and 5.5 from builds, since they are not supported by
DokuWiki anymore [1], and add PHP 7.1.

[1] https://www.dokuwiki.org/requirements?rev=1500491553