### PR TITLE
Fix replacedate to handle empty input; see Issue #192

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -504,12 +504,17 @@ class syntax_plugin_bureaucracy extends DokuWiki_Syntax_Plugin {
     function replacedate($match) {
         global $conf;
 
+        //First check for empty or invalid input
+        if($match[1] == "" || ($t=strtotime($match[1]))===false){
+            return "";
+        }
+
         //no 2nd argument for default date format
         if($match[2] == null) {
             $match[2] = $conf['dformat'];
         }
 
-        return strftime($match[2], strtotime($match[1]));
+        return strftime($match[2], $t);
     }
 
     /**


### PR DESCRIPTION
DATE() will return 1970-01-01 for an empty input. Now, if using a year or part of the date to create namespaces dynamically, this can throw things quite off. This patch adds a check if the supplied date is empty or the strototime() throws an error, and returns an empty string for this case.

This behavior is especially useful for complex forms, where multiple input is possible for the date, and either one or the other is valid only. In my example, running projects and planned projects evaluate differently, and the namespace is composed dynamically based on the input.