### PR TITLE
Add file upload overwrite

### DIFF
--- a/helper/actiontemplate.php
+++ b/helper/actiontemplate.php
@@ -347,6 +347,7 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
             $label = $field->getParam('label');
             $file  = $field->getParam('file');
             $ns    = $field->getParam('namespace');
+            $ow    = $field->getParam('overwrite');
 
             //skip empty files
             if(!$file['size']) {
@@ -366,7 +367,7 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
             $res = media_save(
                 array('name' => $file['tmp_name']),
                 $id,
-                false,
+                $ow,
                 $auth,
                 $move);
 

--- a/helper/field.php
+++ b/helper/field.php
@@ -105,7 +105,7 @@ class helper_plugin_bureaucracy_field extends syntax_plugin_bureaucracy {
                 $this->opt['pagename'] = true;
             } elseif($arg == '@@') {
                 $this->opt['replyto'] = true;
-            } elseif($arg == 'overwrite') {
+            } elseif($arg == '%overwrite') {
                 $this->opt['overwrite'] = true;
             } elseif(preg_match('/x\d/', $arg)) {
                 $this->opt['rows'] = substr($arg,1);

--- a/helper/field.php
+++ b/helper/field.php
@@ -105,6 +105,8 @@ class helper_plugin_bureaucracy_field extends syntax_plugin_bureaucracy {
                 $this->opt['pagename'] = true;
             } elseif($arg == '@@') {
                 $this->opt['replyto'] = true;
+            } elseif($arg == 'overwrite') {
+                $this->opt['overwrite'] = true;
             } elseif(preg_match('/x\d/', $arg)) {
                 $this->opt['rows'] = substr($arg,1);
             } elseif($arg[0] == '.') {

--- a/helper/fieldfile.php
+++ b/helper/fieldfile.php
@@ -9,6 +9,7 @@ class helper_plugin_bureaucracy_fieldfile extends helper_plugin_bureaucracy_fiel
      * Arguments:
      *  - cmd
      *  - label
+     *  - overwrite
      *  - ^ (optional)
      *
      * @param array $args The tokenized definition, only split at spaces
@@ -18,6 +19,8 @@ class helper_plugin_bureaucracy_fieldfile extends helper_plugin_bureaucracy_fiel
 
         //default namespace for file upload (pagepath:file_name)
         $this->opt['namespace'] = '.';
+        //default to not allow overwriting if a namespace:filename conflict exists
+        $this->opt['overwrite'] = false;
 
         //check whenever the first argument is an upload namespace
         if (isset($args[0]) && preg_match('/^[a-z.\-_:]+$/', $args[0])) {


### PR DESCRIPTION
Right now, processUploads() in helper/actiontemplate.php hardcodes media_save()'s $ow argument to false which prevents one from overwriting an already existing file uploaded to the same namespace via a form created using Bureaucracy's "file" field type, even when one wants to allow this.

I needed this in a hurry last night, so I added an "%overwrite" parameter to the line field type that goes after the optional namespace. I'm not tied to the particular name for the parameter - I just needed something that would be easy to track down later, and I prepended "%" to it keep the rest of the plugin from interpreting it as a namespace (especially in helper_plugin_bureaucracy_fieldfile's initialize() function).