### PR TITLE
Trim E-Mail

### DIFF
--- a/helper/fieldemail.php
+++ b/helper/fieldemail.php
@@ -23,7 +23,7 @@ class helper_plugin_bureaucracy_fieldemail extends helper_plugin_bureaucracy_fie
         parent::_validate();
 
         $value = $this->getParam('value');
-        if(!is_null($value) && $value !== '@MAIL@' && !mail_isvalid($value)){
+        if(!is_null($value) && $value !== '@MAIL@' && !mail_isvalid(trim($value))){
             throw new Exception(sprintf($this->getLang('e_email'),hsc($this->getParam('display'))));
         }
     }


### PR DESCRIPTION
E-Mail addresses with blank spaces cause an error in the validation. Maybe you can trim already on previous places and not only at the validation.