### PR TITLE
Add a new parameter "!" to addpage.

### DIFF
--- a/helper/actiontemplate.php
+++ b/helper/actiontemplate.php
@@ -29,6 +29,7 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
         $this->patterns = array();
         $this->values   = array();
         $this->targetpages = array();
+        $this->ignoreExistErrorPages = array();
 
         $this->prepareNamespacetemplateReplacements();
         $this->prepareDateTimereplacements();
@@ -46,8 +47,6 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
         if(empty($this->targetpages)) {
             throw new Exception(sprintf($this->getLang('e_template'), $tpl));
         }
-
-        $this->checkTargetPageNames();
 
         $this->processUploads($fields);
         $this->replaceAndSavePages($fields);
@@ -105,6 +104,11 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
                 $relativetargetpage = $field->getParam('page_tgt');
                 resolve_pageid($ns, $relativeTargetPageid, $ignored);
                 $targetpage = "$this->pagename:$relativetargetpage";
+
+                //ignore exist error
+                if ($field->getParam('page_ignore_exist')) {
+                    array_push($this->ignoreExistErrorPages, $targetpage);
+                }
 
                 $auth = $this->aclcheck($templatepage); // runas
                 if ($auth >= AUTH_READ ) {
@@ -220,24 +224,32 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
     }
 
     /**
-     * Checks for existance and access of target pages
+     * Checks for existance and access of a target page
      *
      * @return mixed
      * @throws Exception
      */
-    protected function checkTargetPageNames() {
-        foreach (array_keys($this->targetpages) as $pname) {
-            // prevent overriding already existing pages
-            if (page_exists($pname)) {
-                throw new Exception(sprintf($this->getLang('e_pageexists'), html_wikilink($pname)));
-            }
+    protected function checkTargetPageName($pname) {
+        // prevent overriding already existing pages
+        if (page_exists($pname)) {
+            throw new Exception(sprintf($this->getLang('e_pageexists'), html_wikilink($pname)));
+        }
 
-            $auth = $this->aclcheck($pname);
-            if ($auth < AUTH_CREATE) {
-                throw new Exception($this->getLang('e_denied'));
-            }
+        $auth = $this->aclcheck($pname);
+        if ($auth < AUTH_CREATE) {
+            throw new Exception($this->getLang('e_denied'));
         }
     }
+
+    /**
+     * Checks if a page existance must be ignored.
+     *
+     * @return bool
+     */
+    protected function ignoreExistError($pname) {
+        return in_array($pname, $this->ignoreExistErrorPages);
+    }
+
 
     /**
      * Perform replacements on the collected templates, and save the pages.
@@ -249,6 +261,16 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
     protected function replaceAndSavePages($fields) {
         global $ID;
         foreach ($this->targetpages as $pageName => $template) {
+            try {
+                $this->checkTargetPageName($pageName);
+            } catch (Exception $e) {
+                if ($this->ignoreExistError($pageName)) {
+                    continue;
+                } else {
+                    throw $e;
+                }
+            }
+
             // set NSBASE var to make certain dataplugin constructs easier
             $this->patterns['__nsbase__'] = '/@NSBASE@/';
             $this->values['__nsbase__'] = noNS(getNS($pageName));

--- a/helper/fieldaddpage.php
+++ b/helper/fieldaddpage.php
@@ -11,6 +11,7 @@ class helper_plugin_bureaucracy_fieldaddpage extends helper_plugin_bureaucracy_f
      *  - cmd
      *  - page_tpl
      *  - page_tgt
+     *  - page_ignore_exist (optional)
      *
      * @param array $args The tokenized definition, only split at spaces
      */
@@ -19,10 +20,19 @@ class helper_plugin_bureaucracy_fieldaddpage extends helper_plugin_bureaucracy_f
             msg(sprintf($this->getLang('e_missingargs'), hsc($args[0]),
                         hsc($args[1])), -1);
             return;
+        } elseif (count($args) == 3) {
+            // add page_ignore_exist default value
+            $args[] = '@';
         }
 
-        // get standard arguments
-        $this->opt = array_combine(array('cmd', 'page_tpl', 'page_tgt'), $args);
+        $this->opt = array_combine(array('cmd', 'page_tpl', 'page_tgt', 'page_ignore_exist'), $args);
+
+        // handle page_ignore_exist
+        if ($this->opt['page_ignore_exist'] == '!') {
+            $this->opt['page_ignore_exist'] = True;
+        } else {
+            $this->opt['page_ignore_exist'] = False;
+        }
     }
 
     /**


### PR DESCRIPTION
With this new parameter, the action template will not throw an error if
the page already exists, but simply ignore it.

With this PR and #275 I can now use the plugin to create a page, and create another one (linked) if it does not exist yet. My use case is adding a book and in the same time a page for the book's author. The second page may already exist, so I don't want to throw an error in this case.