### PR TITLE
Add an event before target page id is built

### DIFF
--- a/helper/actiontemplate.php
+++ b/helper/actiontemplate.php
@@ -44,8 +44,10 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
         );
 
         $event = new Doku_Event('PLUGIN_BUREAUCRACY_PAGENAME', $evdata);
-        $event->advise_before();
-        $this->buildTargetPagename($fields, $sep);
+        if ($event->advise_before()) {
+            $this->buildTargetPagename($fields, $sep);
+        }
+        $event->advise_after();
 
         //target&template(s) from addpage fields
         $this->getAdditionalTargetpages($fields);

--- a/helper/actiontemplate.php
+++ b/helper/actiontemplate.php
@@ -36,6 +36,14 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
         $this->prepareNoincludeReplacement();
         $this->prepareFieldReplacements($fields);
 
+        $evdata = array(
+            'patterns' => &$this->patterns,
+            'values' => &$this->values,
+            'fields' => $fields
+        );
+
+        $event = new Doku_Event('PLUGIN_BUREAUCRACY_PAGENAME', $evdata);
+        $event->advise_before();
         $this->buildTargetPagename($fields, $sep);
 
         //target&template(s) from addpage fields

--- a/helper/actiontemplate.php
+++ b/helper/actiontemplate.php
@@ -39,7 +39,8 @@ class helper_plugin_bureaucracy_actiontemplate extends helper_plugin_bureaucracy
         $evdata = array(
             'patterns' => &$this->patterns,
             'values' => &$this->values,
-            'fields' => $fields
+            'fields' => $fields,
+            'action' => $this
         );
 
         $event = new Doku_Event('PLUGIN_BUREAUCRACY_PAGENAME', $evdata);


### PR DESCRIPTION
This event can be used instead of the later `PLUGIN_BUREAUCRACY_TEMPLATE_SAVE`. Plugins can supply their field values early so that they can be used in page ids. 

I tested this event with the action template and the struct plugin (including saving to the database).