### PR TITLE
Check if form is dirty before exiting page

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,4 @@
 /* DOKUWIKI:include script/fieldsets.js */
 /* DOKUWIKI:include script/user.js */
 /* DOKUWIKI:include script/datepicker.js */
+/* DOKUWIKI:include script/dirty.js */

--- a/script/dirty.js
+++ b/script/dirty.js
@@ -1,0 +1,25 @@
+/**
+ * Detecting data changes in forms using jQuery
+ *
+ * @author Eduardo Mozart de Oliveira <eduardomozart182@gmail.com>
+ */
+jQuery(function () {
+    var initdata = jQuery('form.bureaucracy__plugin').serialize();
+    var submitted = false;
+    
+    jQuery(window).on('beforeunload', function (event) {
+        var nowdata = jQuery('form.bureaucracy__plugin').serialize();
+        
+        if (initdata !== nowdata && !submitted) {
+            event.stopPropagation();
+            event.preventDefault();
+            
+            event.returnValue = true;
+            return true;
+        }
+    });
+    
+    jQuery("form.bureaucracy__plugin").submit(function() {
+        submitted = true;
+    });
+});


### PR DESCRIPTION
This PR checks if form is dirty (aka. has been changed) before exiting the page, preventing that user looses it changes if it exits the page after changing the form data and not submitting it.
Some templates like ReadTheDokus contains navigation buttons that maybe clicked and user lost all it's changes if it clicks on "Previous" (Anterior) or "Next" (Próximo) instead of "Create page" (Criar página) button, so this small improvement avoids that from happening.
![image](https://github.com/user-attachments/assets/7003598b-9924-4ece-b624-abee8253791f)
