### PR TITLE
Support for arbitrary captcha plugins

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -2,3 +2,4 @@
 
 $conf['runas'] = '';
 $conf['maxEmailAttachmentSize']  = 3*1024*1024; //3MB
+$conf['captchaPlugin'] = 'captcha';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -2,4 +2,4 @@
 
 $meta['runas']     = array('string');
 $meta['maxEmailAttachmentSize']  = array('numeric');
-
+$meta['captchaPlugin'] = array('string');

--- a/helper/fieldsubmit.php
+++ b/helper/fieldsubmit.php
@@ -33,10 +33,10 @@ class helper_plugin_bureaucracy_fieldsubmit extends helper_plugin_bureaucracy_fi
     public function renderfield($params, Doku_Form $form, $formid) {
         if(!isset(helper_plugin_bureaucracy_fieldsubmit::$captcha_displayed[$formid])) {
             helper_plugin_bureaucracy_fieldsubmit::$captcha_displayed[$formid] = true;
-            /** @var helper_plugin_captcha $helper */
-            $helper = null;
-            if(@is_dir(DOKU_PLUGIN.'captcha')) $helper = plugin_load('helper','captcha');
-            if(!is_null($helper) && $helper->isEnabled()){
+
+            $captcha = $this->getConf('captchaPlugin') ?: '';
+            $helper = plugin_load('helper', $captcha); // returns PluginInterface|Null
+            if (!is_null($helper) && $helper->isEnabled()) {
                 $form->addElement($helper->getHTML());
             }
         }
@@ -66,9 +66,8 @@ class helper_plugin_bureaucracy_fieldsubmit extends helper_plugin_bureaucracy_fi
         if(!isset(helper_plugin_bureaucracy_fieldsubmit::$captcha_checked[$formid])) {
             helper_plugin_bureaucracy_fieldsubmit::$captcha_checked[$formid] = true;
             // check CAPTCHA
-            /** @var helper_plugin_captcha $helper */
-            $helper = null;
-            if(@is_dir(DOKU_PLUGIN.'captcha')) $helper = plugin_load('helper','captcha');
+            $captcha = $this->getConf('captchaPlugin') ?: '';
+            $helper = plugin_load('helper', $captcha);
             if(!is_null($helper) && $helper->isEnabled()){
                 return $helper->check();
             }
@@ -85,5 +84,4 @@ class helper_plugin_bureaucracy_fieldsubmit extends helper_plugin_bureaucracy_fi
     public function getParam($name) {
         return ($name === 'value') ? null : parent::getParam($name);
     }
-
 }


### PR DESCRIPTION
Allows the use of any captcha plugin by name e.g. captcha, recaptcha, validator etc. The selected plugin must implement `isEnabled()`, `getHTML()`, and `check()`.